### PR TITLE
Fix sign-up redirect for new accounts

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -73,3 +73,68 @@ export async function GET(req: Request) {
   // Redirect to the next page *after* cookies are set
   return NextResponse.redirect(`${origin}${next}`)
 }
+
+export async function POST(req: Request) {
+  const { searchParams, origin } = new URL(req.url)
+  const next = searchParams.get('next') ?? '/market'
+  const accessToken = req.headers.get('x-sb-access-token')
+  const refreshToken = req.headers.get('x-sb-refresh-token')
+
+  if (!accessToken || !refreshToken) {
+    console.warn('No tokens in auth callback')
+    return NextResponse.redirect(`${origin}/campus`)
+  }
+
+  const supabase = await createRouteSupabase()
+  const {
+    data: { session },
+    error: setError,
+  } = await supabase.auth.setSession({
+    access_token: accessToken,
+    refresh_token: refreshToken,
+  })
+
+  if (setError || !session) {
+    console.error('Auth callback error:', setError)
+    return NextResponse.redirect(`${origin}/campus`)
+  }
+
+  const user = session.user
+  const md = (user.user_metadata ?? {}) as {
+    username?: string
+    grade?: string
+    campus_slug?: string
+  }
+
+  // Prefer campus slug from metadata; else fall back to email domain
+  let campusId: string | null = null
+  if (md.campus_slug) {
+    const { data: campusRow } = await supabase
+      .from('campuses')
+      .select('id')
+      .eq('slug', md.campus_slug)
+      .maybeSingle()
+    campusId = campusRow?.id ?? null
+  }
+  if (!campusId && user.email) {
+    const emailDomain = user.email.split('@')[1]?.toLowerCase()
+    const { data: campusRow2 } = await supabase
+      .from('campuses')
+      .select('id')
+      .contains('allowed_domains', [emailDomain])
+      .maybeSingle()
+    campusId = campusRow2?.id ?? null
+  }
+
+  const { error: upsertError } = await supabase.from('profiles').upsert({
+    id: user.id,
+    campus_id: campusId,
+    username: md.username ?? null,
+    grade: md.grade ?? null,
+  })
+  if (upsertError) {
+    console.error('Profile upsert error:', upsertError)
+  }
+
+  return NextResponse.redirect(`${origin}${next}`)
+}

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -61,8 +61,23 @@ export default function AuthPage() {
 
     if (error) return setMsg(error.message)
 
-    // Always go through the callback so profile is created there
-    location.href = `/auth/callback?next=${encodeURIComponent(next)}`
+    // If we received a session immediately, pass the tokens to the
+    // callback route so that it can set auth cookies and create the
+    // profile row on the server. Otherwise (e.g. email confirmation
+    // required) show a notice to the user.
+    const session = data.session
+    if (session) {
+      await fetch(`/auth/callback?next=${encodeURIComponent(next)}`, {
+        method: 'POST',
+        headers: {
+          'x-sb-access-token': session.access_token,
+          'x-sb-refresh-token': session.refresh_token,
+        },
+      })
+      router.push(next)
+    } else {
+      setMsg('Check your email for a confirmation link to finish sign-up.')
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- Send session tokens to auth callback after sign up
- Handle POST requests in auth callback to set cookies and create profile

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a25d598e0832f89f154ffa0e4fdbc