### PR TITLE
Improve campus selection and auth flows

### DIFF
--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -1,0 +1,94 @@
+'use client'
+import { useEffect, useMemo, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { supabase } from '@/lib/supabase/client'
+
+export default function SignInPage() {
+  const params = useSearchParams()
+  const router = useRouter()
+  const next = params.get('next') ?? '/market'
+
+  const [campusSlug, setCampusSlug] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [campusDomains, setCampusDomains] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState<string | null>(null)
+
+  useEffect(() => {
+    const match = document.cookie.match(/(?:^|; )dx-campus=([^;]*)/)
+    setCampusSlug(match ? decodeURIComponent(match[1]) : '')
+  }, [])
+
+  useEffect(() => {
+    if (!campusSlug) return
+    supabase
+      .from('campuses')
+      .select('allowed_domains')
+      .eq('slug', campusSlug)
+      .maybeSingle()
+      .then(({ data }) => setCampusDomains((data?.allowed_domains as string[]) ?? []))
+  }, [campusSlug])
+
+  const emailDomain = useMemo(() => email.split('@')[1]?.toLowerCase() ?? '', [email])
+  const domainOk = campusDomains.length === 0 || campusDomains.includes(emailDomain)
+
+  async function handleSignIn(e: React.FormEvent) {
+    e.preventDefault()
+    setMsg(null)
+    if (!domainOk) return setMsg(`Use your school email (${campusDomains.join(', ')})`)
+    setLoading(true)
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password })
+    setLoading(false)
+    if (error) return setMsg(error.message)
+    const session = data.session
+    if (session) {
+      await fetch(`/auth/callback?next=${encodeURIComponent(next)}`, {
+        method: 'POST',
+        headers: {
+          'x-sb-access-token': session.access_token,
+          'x-sb-refresh-token': session.refresh_token,
+        },
+      })
+      router.push(next)
+    }
+  }
+
+  return (
+    <main className="container mx-auto max-w-md px-4 py-10">
+      <h1 className="mb-2 text-3xl font-bold">Sign in</h1>
+      <p className="mb-6 opacity-80">Campus: <span className="font-medium">{campusSlug}</span></p>
+      <form onSubmit={handleSignIn} className="space-y-4">
+        <input
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder={`yourname@${campusDomains[0] ?? 'school.edu'}`}
+          className={`w-full rounded-xl px-4 py-3 bg-white/10 outline-none placeholder:opacity-70 ${domainOk || !email ? '' : 'ring-2 ring-red-500'}`}
+        />
+        <input
+          type="password"
+          required
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="w-full rounded-xl px-4 py-3 bg-white/10 outline-none placeholder:opacity-70"
+        />
+        {!domainOk && email && (
+          <p className="text-sm text-red-400">Use your school email: {campusDomains.join(', ')}</p>
+        )}
+        <button
+          disabled={loading}
+          className="w-full rounded-xl bg-yellow-400 px-4 py-3 font-semibold text-black disabled:opacity-60"
+        >
+          {loading ? 'Signing in…' : 'Sign in'}
+        </button>
+        {msg && <p className="text-sm opacity-80">{msg}</p>}
+      </form>
+      <p className="mt-6 text-center text-sm opacity-80">
+        Need an account? <a href="/auth" className="underline">Sign up</a>
+      </p>
+    </main>
+  )
+}

--- a/app/campus/page.tsx
+++ b/app/campus/page.tsx
@@ -1,14 +1,25 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase/client'
 
-const CAMPUSES = [
-  { slug: 'demo-university', name: 'Demo University' },
-  { slug: 'example-college', name: 'Example College' },
-]
+interface Campus {
+  slug: string
+  name: string
+  hero_image_url: string | null
+}
 
 export default function CampusPage() {
   const router = useRouter()
+  const [campuses, setCampuses] = useState<Campus[]>([])
+
+  useEffect(() => {
+    supabase
+      .from('campuses')
+      .select('name, slug, hero_image_url')
+      .then(({ data }) => setCampuses(data ?? []))
+  }, [])
 
   async function choose(slug: string) {
     await fetch('/api/campus', {
@@ -21,15 +32,23 @@ export default function CampusPage() {
 
   return (
     <main className="container mx-auto px-4 py-10">
-      <h1 className="text-4xl font-bold mb-6">Choose your campus</h1>
-      <ul className="space-y-4">
-        {CAMPUSES.map((c) => (
+      <h1 className="mb-6 text-center text-4xl font-bold">Choose your campus</h1>
+      <ul className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {campuses.map((c) => (
           <li key={c.slug}>
             <button
               onClick={() => choose(c.slug)}
-              className="w-full text-left px-4 py-3 rounded-xl bg-white/10 hover:bg-white/20 transition"
-            >
-              {c.name}
+              className="w-full overflow-hidden rounded-xl text-left">
+              {c.hero_image_url && (
+                <img
+                  src={c.hero_image_url}
+                  alt={c.name}
+                  className="h-32 w-full object-cover"
+                />
+              )}
+              <div className="px-4 py-3 bg-white/10 transition hover:bg-white/20">
+                {c.name}
+              </div>
             </button>
           </li>
         ))}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,9 +12,9 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className="bg-bg text-white antialiased">
+      <body className="flex min-h-screen flex-col bg-bg text-white antialiased">
         <Navbar />
-        {children}
+        <main className="flex-1">{children}</main>
         <Footer /> {/* ⬅️ render Footer after page content */}
       </body>
     </html>

--- a/app/market/page.tsx
+++ b/app/market/page.tsx
@@ -4,6 +4,7 @@ import { createServerSupabase } from '@/lib/supabase/server'
 import Image from 'next/image'
 import Link from 'next/link'
 import FavButton from './FavButton'
+import stockListings from '@/data/listings.json'
 
 export default async function MarketPage() {
   const { user, campus } = await requireAuthAndCampus()
@@ -30,16 +31,35 @@ export default async function MarketPage() {
     .eq('user_id', user.id)
   const favSet = new Set((favs ?? []).map((f) => f.listing_id))
 
+  let display = listings ?? []
+  let showFav = true
+  if (!display.length) {
+    display = (stockListings as any[])
+      .filter(
+        (l) =>
+          l.campus &&
+          l.campus.toLowerCase().replace(/\s+/g, '-') === campus
+      )
+      .map((l) => ({
+        id: l.id,
+        title: l.title,
+        price_cents: (l.price ?? 0) * 100,
+        image_url: l.imageUrls?.[0] ?? null,
+        condition: l.condition,
+      }))
+    showFav = false
+  }
+
   return (
     <main className="container mx-auto px-4 py-8">
-      <div className="flex items-center justify-between mb-6">
+      <div className="mb-6 flex items-center justify-between">
         <h1 className="text-3xl font-bold">Buy & Sell on Campus</h1>
-        <Link href="/profile" className="rounded-xl px-4 py-2 bg-white/10">Profile</Link>
+        <Link href="/profile" className="rounded-xl bg-white/10 px-4 py-2">Profile</Link>
       </div>
 
-      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        {(listings ?? []).map((l) => (
-          <ListingCard key={l.id} listing={l} isFav={favSet.has(l.id)} />
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {display.map((l) => (
+          <ListingCard key={l.id} listing={l} isFav={favSet.has(l.id)} showFav={showFav} />
         ))}
       </div>
     </main>
@@ -50,7 +70,7 @@ function Price({ cents }: { cents: number }) {
   return <span>${(cents / 100).toFixed(0)}</span>
 }
 
-function ListingCard({ listing, isFav }: { listing: any; isFav: boolean }) {
+function ListingCard({ listing, isFav, showFav }: { listing: any; isFav: boolean; showFav: boolean }) {
   return (
     <div className="rounded-2xl overflow-hidden bg-white/5 border border-white/10">
       <div className="relative h-44">
@@ -62,7 +82,7 @@ function ListingCard({ listing, isFav }: { listing: any; isFav: boolean }) {
           <div className="text-sm opacity-80">{listing.condition}</div>
           <div className="mt-1 font-bold"><Price cents={listing.price_cents} /></div>
         </div>
-        <FavButton listingId={listing.id} initial={isFav} />
+        {showFav && <FavButton listingId={listing.id} initial={isFav} />}
       </div>
     </div>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,14 @@
 export default function Home() {
   return (
-    <main className="container mx-auto px-4 py-10">
-      <h1 className="text-4xl font-bold mb-6">Welcome to DormExchange</h1>
-      <p className="mb-4">Buy and sell items with other students.</p>
+    <main className="container mx-auto flex min-h-[70vh] flex-col items-center justify-center px-4 text-center">
+      <h1 className="mb-6 text-4xl font-bold">Welcome to DormExchange</h1>
+      <p className="mb-8 max-w-xl opacity-90">
+        DormExchange is the campus marketplace where students can buy and sell
+        textbooks, furniture and everything in between with classmates.
+      </p>
       <a
         href="/campus"
-        className="inline-block px-4 py-2 bg-yellow-400 text-black rounded-xl"
+        className="inline-block rounded-xl bg-yellow-400 px-6 py-3 font-medium text-black"
       >
         Choose your campus
       </a>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -8,29 +8,55 @@ export default async function ProfilePage() {
   if (!campus) redirect('/campus')
 
   const supabase = await createServerSupabase()
-  const [{ data: profile }, { data: favs }] = await Promise.all([
-    supabase
-      .from('profiles')
-      .select('full_name')
-      .eq('id', user.id)
-      .maybeSingle(),
+  const [{ data: profile }, { data: favs }, { data: myListings }] = await Promise.all([
+    supabase.from('profiles').select('username').eq('id', user.id).maybeSingle(),
     supabase
       .from('favorites')
       .select('listing_id, listings(title, price_cents, image_url)')
+      .eq('user_id', user.id)
+      .returns<any[]>(),
+    supabase
+      .from('listings')
+      .select('id, title, price_cents')
       .eq('user_id', user.id)
       .returns<any[]>(),
   ])
 
   return (
     <main className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-4">Your Profile</h1>
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-3xl font-bold">Your Profile</h1>
+        <a
+          href="/messages"
+          className="rounded-xl bg-white/10 px-4 py-2 font-medium"
+        >
+          Messages
+        </a>
+      </div>
       <div className="space-y-6">
-        <section className="bg-white/5 rounded-2xl p-4">
-          <div className="font-semibold">Email</div>
-          <div className="opacity-80">{user.email}</div>
+        <section className="rounded-2xl bg-white/5 p-4 space-y-2">
+          <div>
+            <div className="font-semibold">Email</div>
+            <div className="opacity-80">{user.email}</div>
+          </div>
+          <div>
+            <div className="font-semibold">Username</div>
+            <div className="opacity-80">{profile?.username}</div>
+          </div>
         </section>
-        <section className="bg-white/5 rounded-2xl p-4">
-          <div className="font-semibold mb-2">Saved Items</div>
+        <section className="rounded-2xl bg-white/5 p-4">
+          <div className="mb-2 font-semibold">Your Listings</div>
+          <ul className="space-y-2">
+            {(myListings ?? []).map((l) => (
+              <li key={l.id} className="flex items-center justify-between">
+                <span>{l.title}</span>
+                <span className="opacity-70">${(l.price_cents ?? 0) / 100}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+        <section className="rounded-2xl bg-white/5 p-4">
+          <div className="mb-2 font-semibold">Saved Items</div>
           <ul className="space-y-2">
             {(favs ?? []).map((f) => (
               <li key={f.listing_id} className="flex items-center justify-between">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -42,7 +42,7 @@ export default function Navbar() {
             </button>
           ) : (
             <Link
-              href="/auth"
+              href="/auth/signin"
               className="px-3 py-1.5 rounded-xl bg-yellow-400 text-black"
             >
               Sign in


### PR DESCRIPTION
## Summary
- Style landing page with centered campus call-to-action
- Fetch campuses from Supabase and add email domain restrictions to sign-in
- Show user details, listings, and messages link on profile; use stock listings fallback
- Keep footer fixed at bottom

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(compiled with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689a4a3e9fe4832fbe5e4c691c828f16